### PR TITLE
cpu/nrf52: blacklist OPTIONAL_FLAGS for use with gcc 6.3

### DIFF
--- a/boards/pinetime/Makefile.include
+++ b/boards/pinetime/Makefile.include
@@ -2,5 +2,12 @@
 RIOT_TERMINAL ?= jlink
 include $(RIOTMAKE)/tools/serial.inc.mk
 
+ifeq (pyocd,$(PROGRAMMER))
+  # The board is not recognized automatically by pyocd, so the CPU target
+  # option is passed explicitly
+  export FLASH_TARGET_TYPE ?= -t $(CPU)
+  include $(RIOTMAKE)/tools/pyocd.inc.mk
+endif
+
 # use shared Makefile.include
 include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/boards/pinetime/board.c
+++ b/boards/pinetime/board.c
@@ -23,7 +23,30 @@
 
 #include "cpu.h"
 #include "board.h"
+#include "mtd.h"
+#include "mtd_spi_nor.h"
 #include "periph/gpio.h"
+#include "periph/spi.h"
+
+#ifdef MODULE_MTD
+static mtd_spi_nor_t pinetime_nor_dev = {
+    .base = {
+        .driver = &mtd_spi_nor_driver,
+        .page_size = 256,
+        .pages_per_sector = 16,
+        .sector_count = 2048,
+    },
+    .flag = SPI_NOR_F_SECT_4K | SPI_NOR_F_SECT_32K,
+    .opcode = &mtd_spi_nor_opcode_default,
+    .spi = PINETIME_NOR_SPI_DEV,
+    .cs = PINETIME_NOR_SPI_CS,
+    .addr_width = 3,
+    .mode = PINETIME_NOR_SPI_MODE,
+    .clk = PINETIME_NOR_SPI_CLK,
+};
+
+mtd_dev_t *mtd0 = (mtd_dev_t *)&pinetime_nor_dev;
+#endif /* MODULE_MTD */
 
 void board_init(void)
 {

--- a/boards/pinetime/include/board.h
+++ b/boards/pinetime/include/board.h
@@ -23,6 +23,7 @@
 
 #include "cpu.h"
 #include "board_common.h"
+#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -64,6 +65,24 @@ extern "C" {
 #define ILI9341_PARAM_RGB          1
 #define ILI9341_PARAM_INVERTED     1
 #define ILI9341_PARAM_NUM_LINES    240U
+/** @} */
+
+/**
+ * @name PineTime NOR flash hardware configuration
+ */
+/** @{ */
+#define PINETIME_NOR_SPI_DEV               SPI_DEV(0)
+#define PINETIME_NOR_SPI_CLK               SPI_CLK_10MHZ
+#define PINETIME_NOR_SPI_CS                GPIO_PIN(0, 5)
+#define PINETIME_NOR_SPI_MODE              SPI_MODE_3
+/** @} */
+
+/**
+ * @name MTD configuration
+ */
+/** @{ */
+extern mtd_dev_t *mtd0;
+#define MTD_0 mtd0
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/pinetime/include/board.h
+++ b/boards/pinetime/include/board.h
@@ -49,7 +49,7 @@ extern "C" {
 #define VCC33                       GPIO_PIN(0, 24)
 #define POWER_PRESENCE              GPIO_PIN(0, 19)
 #define CHARGING_ACTIVE             GPIO_PIN(0, 12)
-#define BATTERY_ADC                 NRF52
+#define BATTERY_ADC                 NRF52_AIN7
 /** @} */
 
 /**

--- a/cpu/nrf52/Makefile.include
+++ b/cpu/nrf52/Makefile.include
@@ -27,5 +27,9 @@ RAM_START_ADDR ?= 0x20000000
 
 LINKER_SCRIPT ?= cortexm.ld
 
+OPTIONAL_CFLAGS_BLACKLIST += -Wformat-overflow
+OPTIONAL_CFLAGS_BLACKLIST += -Wformat-truncation
+OPTIONAL_CFLAGS_BLACKLIST += -gz
+
 include $(RIOTCPU)/nrf5x_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/nrf5x_common/periph/spi.c
+++ b/cpu/nrf5x_common/periph/spi.c
@@ -117,7 +117,7 @@ void spi_release(spi_t bus)
     mutex_unlock(&locks[bus]);
 }
 
-#ifndef CPU
+#ifndef CPU_FAM_NRF51
 /**
  * @brief Work-around for transmitting 1 byte with SPIM.
  *
@@ -131,7 +131,7 @@ void spi_release(spi_t bus)
 static void _setup_workaround_for_ftpan_58(spi_t bus)
 {
     // Create an event when SCK toggles.
-    NRF_GPIOTE->CONFIG[bus] = (
+    NRF_GPIOTE->CONFIG[bus + 7] = (
         GPIOTE_CONFIG_MODE_Event <<
         GPIOTE_CONFIG_MODE_Pos
         ) | (
@@ -143,7 +143,7 @@ static void _setup_workaround_for_ftpan_58(spi_t bus)
         );
 
     // Stop the spim instance when SCK toggles.
-    NRF_PPI->CH[bus].EEP = (uint32_t)&NRF_GPIOTE->EVENTS_IN[bus];
+    NRF_PPI->CH[bus].EEP = (uint32_t)&NRF_GPIOTE->EVENTS_IN[bus + 7];
     NRF_PPI->CH[bus].TEP = (uint32_t)&dev(bus)->TASKS_STOP;
 }
 

--- a/cpu/nrf5x_common/periph/spi.c
+++ b/cpu/nrf5x_common/periph/spi.c
@@ -20,6 +20,8 @@
  *
  * @}
  */
+#include <stdio.h>
+#include <string.h>
 
 #include "cpu.h"
 #include "mutex.h"
@@ -27,15 +29,31 @@
 #include "periph/spi.h"
 #include "periph/gpio.h"
 
+#define SPI_CPU_FLASH_END  (CPU_FLASH_BASE + FLASHPAGE_NUMOF * FLASHPAGE_SIZE)
+
+#define THREAD_FLAG_SPI_BUS     (1<<10)
+
 /**
  * @brief   array holding one pre-initialized mutex for each SPI device
  */
 static mutex_t locks[SPI_NUMOF];
+static kernel_pid_t pid[SPI_NUMOF];
 
+static uint8_t _mbuf[SPI_NUMOF][UINT8_MAX];
+
+static void _setup_workaround_for_ftpan_58(spi_t bus);
+
+#ifdef CFU_FAM_NRF51
 static inline NRF_SPI_Type *dev(spi_t bus)
 {
     return spi_config[bus].dev;
 }
+#else
+static inline NRF_SPIM_Type *dev(spi_t bus)
+{
+    return (NRF_SPIM_Type *)spi_config[bus].dev;
+}
+#endif
 
 void spi_init(spi_t bus)
 {
@@ -45,6 +63,7 @@ void spi_init(spi_t bus)
     mutex_init(&locks[bus]);
     /* initialize pins */
     spi_init_pins(bus);
+    NVIC_EnableIRQ(SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQn);
 }
 
 void spi_init_pins(spi_t bus)
@@ -54,9 +73,17 @@ void spi_init_pins(spi_t bus)
     gpio_init(spi_config[bus].mosi, GPIO_OUT);
     gpio_init(spi_config[bus].miso, GPIO_IN);
     /* select pins for the SPI device */
+#ifdef CPU_FAM_NRF51
     SPI_SCKSEL  = spi_config[bus].sclk;
     SPI_MOSISEL = spi_config[bus].mosi;
     SPI_MISOSEL = spi_config[bus].miso;
+#else
+    dev(bus)->PSEL.SCK  = spi_config[bus].sclk;
+    dev(bus)->PSEL.MOSI = spi_config[bus].mosi;
+    dev(bus)->PSEL.MISO = spi_config[bus].miso;
+
+    _setup_workaround_for_ftpan_58(bus);
+#endif
 }
 
 int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
@@ -72,8 +99,11 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
     dev(bus)->CONFIG = mode;
     dev(bus)->FREQUENCY = clk;
     /* enable the bus */
+#ifdef CPU_FAM_NRF51
     dev(bus)->ENABLE = 1;
-
+#else
+    dev(bus)->ENABLE = SPIM_ENABLE_ENABLE_Enabled;
+#endif
     return SPI_OK;
 }
 
@@ -87,6 +117,72 @@ void spi_release(spi_t bus)
     mutex_unlock(&locks[bus]);
 }
 
+#ifndef CPU
+/**
+ * @brief Work-around for transmitting 1 byte with SPIM.
+ *
+ * @param spim: The SPIM instance that is in use.
+ * @param ppi_channel: An unused PPI channel that will be used by the workaround.
+ * @param gpiote_channel: An unused GPIOTE channel that will be used by the workaround.
+ *
+ * @warning Must not be used when transmitting multiple bytes.
+ * @warning After this workaround is used, the user must reset the PPI channel and the GPIOTE channel before attempting to transmit multiple bytes.
+ */
+static void _setup_workaround_for_ftpan_58(spi_t bus)
+{
+    // Create an event when SCK toggles.
+    NRF_GPIOTE->CONFIG[bus] = (
+        GPIOTE_CONFIG_MODE_Event <<
+        GPIOTE_CONFIG_MODE_Pos
+        ) | (
+        spi_config[bus].sclk <<
+        GPIOTE_CONFIG_PSEL_Pos
+        ) | (
+        GPIOTE_CONFIG_POLARITY_Toggle <<
+        GPIOTE_CONFIG_POLARITY_Pos
+        );
+
+    // Stop the spim instance when SCK toggles.
+    NRF_PPI->CH[bus].EEP = (uint32_t)&NRF_GPIOTE->EVENTS_IN[bus];
+    NRF_PPI->CH[bus].TEP = (uint32_t)&dev(bus)->TASKS_STOP;
+}
+
+static void _enable_workaround(spi_t bus)
+{
+    NRF_PPI->CHENSET = 1U << bus;
+    // The spim instance cannot be stopped mid-byte, so it will finish
+    // transmitting the first byte and then stop. Effectively ensuring
+    // that only 1 byte is transmitted.
+}
+
+static void _clear_workaround(spi_t bus)
+{
+    NRF_PPI->CHENCLR = 1U << bus;
+}
+
+static void _transfer(spi_t bus, const uint8_t *out_buf, uint8_t *in_buf, uint8_t transfer_len)
+{
+    uint8_t out_len = (out_buf) ? transfer_len : 0;
+    uint8_t in_len = (in_buf) ? transfer_len : 0;
+    const uint8_t *out_mbuf = out_buf;
+    if ((out_buf < (uint8_t*)SPI_CPU_FLASH_END) && (out_len)) {
+        memcpy(_mbuf[bus], out_buf, out_len);
+        out_mbuf = _mbuf[bus];
+    }
+    dev(bus)->TXD.PTR = (uint32_t)out_mbuf;
+    dev(bus)->RXD.PTR = (uint32_t)in_buf;
+
+    dev(bus)->TXD.MAXCNT = out_len;
+    dev(bus)->RXD.MAXCNT = in_len;
+
+    dev(bus)->EVENTS_END = 0;
+
+    dev(bus)->TASKS_START = 1;
+}
+#endif
+
+
+
 void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
                         const void *out, void *in, size_t len)
 {
@@ -98,7 +194,7 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
     if (cs != SPI_CS_UNDEF) {
         gpio_clear((gpio_t)cs);
     }
-
+#ifdef CPU_FAM_NRF51
     for (int i = 0; i < (int)len; i++) {
         uint8_t tmp = (out_buf) ? out_buf[i] : 0;
 
@@ -111,8 +207,44 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
             in_buf[i] = tmp;
         }
     }
+#else
+    dev(bus)->RXD.LIST = 0;
+    dev(bus)->TXD.LIST = 0;
+
+    if (len == 1) {
+        _enable_workaround(bus);
+        _transfer(bus, out_buf, in_buf, len);
+        while (dev(bus)->EVENTS_END != 1);
+        _clear_workaround(bus);
+    }
+    else {
+        // Enable IRQ
+        dev(bus)->EVENTS_END = 0;
+        pid[bus] = sched_active_pid;
+        dev(bus)->INTENSET = SPIM_INTENSET_END_Msk;
+        do {
+            size_t transfer_len = len > UINT8_MAX ? UINT8_MAX : len;
+            _transfer(bus, out_buf, in_buf, transfer_len);
+            thread_flags_wait_one(THREAD_FLAG_SPI_BUS);
+            out_buf += out_buf ? transfer_len : 0;
+            in_buf += in_buf? transfer_len : 0;
+            len -= transfer_len;
+        } while (len);
+        dev(bus)->INTENCLR = SPIM_INTENCLR_END_Msk;
+    }
+#endif
 
     if ((cs != SPI_CS_UNDEF) && (!cont)) {
         gpio_set((gpio_t)cs);
     }
 }
+
+#ifndef CPU_FAM_NRF51
+/* TODO: rework to allow arbitrary SPI peripheral order */
+void isr_spi0_twi0(void)
+{
+    thread_flags_set((thread_t*)thread_get(pid[0]), THREAD_FLAG_SPI_BUS);
+    dev(0)->EVENTS_END = 0;
+    cortexm_isr_end();
+}
+#endif

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -689,10 +689,21 @@ ifneq (,$(filter ws281x,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter lis3mdl,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+  USEMODULE += xtimer
+endif
+
 ifneq (,$(filter xbee,$(USEMODULE)))
   FEATURES_REQUIRED += periph_uart
   FEATURES_REQUIRED += periph_gpio
   USEMODULE += ieee802154
   USEMODULE += xtimer
   USEMODULE += netif
+endif
+
+ifneq (,$(filter xpt2046,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_gpio_irq
+  FEATURES_REQUIRED += periph_spi
 endif

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -130,6 +130,13 @@ ifneq (,$(filter ccs811,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter cst816s,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio_irq
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_i2c
+  USEMODULE += xtimer
+endif
+
 ifneq (,$(filter dcf77,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
   FEATURES_REQUIRED += periph_gpio_irq

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -54,6 +54,10 @@ ifneq (,$(filter ccs811,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/ccs811/include
 endif
 
+ifneq (,$(filter cst816s,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/cst816s/include
+endif
+
 ifneq (,$(filter dcf77,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/dcf77/include
 endif

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -349,3 +349,7 @@ endif
 ifneq (,$(filter xbee,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/xbee/include
 endif
+
+ifneq (,$(filter xpt2046,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/xpt2046/include
+endif

--- a/drivers/cst816s/Makefile
+++ b/drivers/cst816s/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/cst816s/cst816s.c
+++ b/drivers/cst816s/cst816s.c
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_cst816s
+ * @{
+ *
+ * @file
+ * @brief       Device driver implementation for cst816s touch screen
+ *
+ * @author      koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+
+#include "log.h"
+#include "periph/gpio.h"
+#include "periph/i2c.h"
+#include "xtimer.h"
+
+#include "cst816s.h"
+#include "cst816s_internal.h"
+
+#define ENABLE_DEBUG        (0)
+#include "debug.h"
+
+static void _gpio_irq(void *arg)
+{
+    cst816s_t *dev = arg;
+    dev->cb(dev, dev->cb_arg);
+}
+
+static void _cst816s_reset(cst816s_t *dev)
+{
+    /* Reset, sleep durations based on
+     * https://github.com/lupyuen/hynitron_i2c_cst0xxse/blob/master/cst0xx_core.c#L1078-L1085 */
+    gpio_clear(dev->params->reset);
+    xtimer_usleep(CST816S_RESET_DURATION_LOW);
+    gpio_set(dev->params->reset);
+    xtimer_usleep(CST816S_RESET_DURATION_HIGH);
+}
+
+#if 0
+static uint16_t _cst816s_chip_id(cst816s_t *dev)
+{
+    uint16_t id = 0;
+    i2c_acquire(dev->params->i2c_dev);
+    int res = i2c_read_reg(dev->params->i2c_dev, dev->params->i2c_addr,
+                 CST816S_REG_FW_VER, &id, 0);
+    if (res < 0) {
+        DEBUG("[cst816s]: Error reading chip id device %d\n", res);
+    }
+    i2c_release(dev->params->i2c_dev);
+    DEBUG("[cst816s]: chip id is %d.\n", id);
+    return id;
+}
+#endif
+
+int cst816s_suspend(cst816s_t *dev)
+{
+    gpio_irq_disable(dev->params->irq);
+    i2c_acquire(dev->params->i2c_dev);
+    int res = i2c_write_reg(dev->params->i2c_dev, dev->params->i2c_addr,
+                            0xA5, 0x05, 0);
+    i2c_release(dev->params->i2c_dev);
+    if (res < 0) {
+        DEBUG("[cst816s]: Error suspending the device %d\n", res);
+    }
+    return res;
+}
+
+void cst816s_resume(cst816s_t *dev)
+{
+    _cst816s_reset(dev);
+    gpio_irq_enable(dev->params->irq);
+}
+
+int cst816s_read(cst816s_t *dev, cst816s_touch_data_t *data, size_t num)
+{
+    uint8_t buf[64];
+    size_t num_points_found = 0;
+
+    i2c_acquire(dev->params->i2c_dev);
+
+    int res = i2c_read_regs(dev->params->i2c_dev, dev->params->i2c_addr,
+                            0, buf, sizeof(buf), 0);
+    i2c_release(dev->params->i2c_dev);
+    if (res < 0) {
+        return res;
+    }
+    uint8_t points = buf[2] & 0x0f;
+    DEBUG("[cst816s] Number of points: %u\n", points);
+
+    size_t max_points_copy = points < num ? points : num;
+    for (size_t i = 0; i < max_points_copy; i++) {
+        uint8_t *point_buf = &buf[3 + 6 * i];
+        uint8_t point_id = point_buf[2] >> 4;
+        if (point_id > 0x0f) {
+            break;
+        }
+        num_points_found++;
+
+        data[i].finger = point_id;
+        data[i].x = (point_buf[0] & 0x0f) << 8 | point_buf[1];
+        data[i].y = (point_buf[2] & 0x0f) << 8 | point_buf[3];
+
+        data[i].action = point_buf[0] >> 6;
+    }
+
+    return num_points_found;
+}
+
+int cst816s_init(cst816s_t *dev, const cst816s_params_t *params,
+                 cst816s_irq_cb_t cb, void *arg)
+{
+    assert(dev && params);
+    dev->params = params;
+    dev->cb = cb;
+    dev->cb_arg = arg;
+
+    gpio_init(dev->params->reset, GPIO_OUT);
+    _cst816s_reset(dev);
+
+    if (cb) {
+        int res = gpio_init_int(dev->params->irq, GPIO_IN, dev->params->irq_flank,
+                                _gpio_irq, dev);
+        if (res < 0) {
+            return CST816S_ERR_IRQ;
+        }
+    }
+    return CST816S_OK;
+    /* The device will not respond until the first touch event */
+}

--- a/drivers/cst816s/include/cst816s_internal.h
+++ b/drivers/cst816s/include/cst816s_internal.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef CST816S_INTERNAL_H
+#define CST816S_INTERNAL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define CST816S_RESET_DURATION_LOW      (20 * US_PER_MS)
+#define CST816S_RESET_DURATION_HIGH     (400 * US_PER_MS)
+
+#define CST816S_REG_INT_CNT                     0x8F
+#define CST816S_REG_FLOW_WORK_CNT               0x91
+#define CST816S_REG_WORKMODE                    0x00
+#define CST816S_REG_WORKMODE_FACTORY_VALUE      0x40
+#define CST816S_REG_WORKMODE_WORK_VALUE         0x00
+#define CST816S_REG_CHIP_ID                     0xA3
+#define CST816S_REG_CHIP_ID2                    0x9F
+#define CST816S_REG_POWER_MODE                  0xA5
+#define CST816S_REG_FW_VER                      0xA6
+#define CST816S_REG_VENDOR_ID                   0xA8
+#define CST816S_REG_LCD_BUSY_NUM                0xAB
+#define CST816S_REG_FACE_DEC_MODE_EN            0xB0
+#define CST816S_REG_GLOVE_MODE_EN               0xC0
+#define CST816S_REG_COVER_MODE_EN               0xC1
+#define CST816S_REG_CHARGER_MODE_EN             0x8B
+#define CST816S_REG_GESTURE_EN                  0xD0
+#define CST816S_REG_GESTURE_OUTPUT_ADDRESS      0xD3
+#define CST816S_REG_ESD_SATURATE                0xED
+
+#define CST816S_REG_POWER_MODE_SLEEP_VALUE      0x03
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CST816_INTERNAL_H */
+/** @} */

--- a/drivers/cst816s/include/cst816s_params.h
+++ b/drivers/cst816s/include/cst816s_params.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+
+/**
+ * @ingroup     drivers_cst816s
+ *
+ * @brief       Default configuration for the CST816S touch screen driver
+ *
+ *
+ * @author      koen Zandberg <koen@bergzand.net>
+ */
+
+#ifndef CST816S_PARAMS_H
+#define CST816S_PARAMS_H
+
+#include "board.h"
+#include "cst816s.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Set default configuration parameters for the CST816S
+ * @{
+ */
+/* I2C configuration */
+#ifndef CST816S_PARAM_I2C_DEV
+#define CST816S_PARAM_I2C_DEV        I2C_DEV(0)
+#endif
+
+#ifndef CST816S_PARAM_I2C_ADDR
+#define CST816S_PARAM_I2C_ADDR       (0x15)
+#endif
+
+#ifndef CST816S_PARAM_IRQ
+#define CST816S_PARAM_IRQ            GPIO_PIN(0, 28)
+#endif
+
+#ifndef CST816S_PARAM_IRQ_FLANK
+#define CST816S_PARAM_IRQ_FLANK      GPIO_FALLING
+#endif
+
+#ifndef CST816S_PARAM_RESET
+#define CST816S_PARAM_RESET          GPIO_PIN(0, 10)
+#endif
+
+
+#define CST816S_PARAMS                      \
+    {                                       \
+        .i2c_dev   = CST816S_PARAM_I2C_DEV,  \
+        .i2c_addr  = CST816S_PARAM_I2C_ADDR, \
+        .irq       = CST816S_PARAM_IRQ,       \
+        .irq_flank = CST816S_PARAM_IRQ_FLANK, \
+        .reset     = CST816S_PARAM_RESET,    \
+    }
+/**@}*/
+
+/**
+ * @brief   Configure BMX280
+ */
+static const cst816s_params_t cst816s_params[] =
+{
+   CST816S_PARAMS
+};
+
+/**
+ * @brief   The number of configured sensors
+ */
+#define CST816S_NUMOF    ARRAY_SIZE(cst816s_params)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BMX280_PARAMS_H */
+/** @} */
+

--- a/drivers/ili9341/ili9341.c
+++ b/drivers/ili9341/ili9341.c
@@ -314,6 +314,17 @@ void ili9341_invert_off(ili9341_t *dev)
 void ili9341_set_brightness(ili9341_t *dev, uint8_t brightness)
 {
     ili9341_write_cmd(dev, ILI9341_CMD_WRDISBV, &brightness, 1);
-    uint8_t param = 0x26;
+    static const uint8_t param = 0x2C;
     ili9341_write_cmd(dev, ILI9341_CMD_WRCTRLD, &param, 1);
+}
+
+void ili9341_sleep_mode(ili9341_t *dev, bool enable)
+{
+    if (enable) {
+        ili9341_write_cmd(dev, ILI9341_CMD_SPLIN, NULL, 0);
+    }
+    else {
+        ili9341_write_cmd(dev, ILI9341_CMD_SLPOUT, NULL, 0);
+        xtimer_usleep(5 * US_PER_MS);
+    }
 }

--- a/drivers/include/cst816s.h
+++ b/drivers/include/cst816s.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_cst816s Cst816S touch screen driver
+ *
+ * @ingroup     drivers_sensors
+ * @brief       Device driver interface for the Hynitron CST816S touch screen
+ *
+ * @{
+ * @file
+ * @brief       Device driver interface for the CST816S touch screen
+ *
+ * @author      koen Zandberg <koen@bergzand.net>
+ */
+
+#ifndef CST816S_H
+#define CST816S_H
+
+#include <stdint.h>
+
+#include "periph/i2c.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct _cst816s cst816s_t;
+
+typedef void (*cst816s_irq_cb_t)(cst816s_t *dev, void *arg);
+
+/**
+ * @brief cst816s touch event touch state
+ */
+typedef enum {
+    CST816S_TOUCH_DOWN = 0,
+    CST816S_TOUCH_UP = 1,
+    CST816S_TOUCH_CONTACT = 2,
+} cst816s_touch_t;
+
+/**
+ * @brief cst816s touch event data
+ */
+typedef struct {
+    uint16_t x;         /**< X coordinate */
+    uint16_t y;         /**< Y coordinate */
+    uint8_t  action;    /**< One of @ref cst816s_touch_t */
+    uint8_t  finger;    /**< Finger index */
+    uint8_t  pressure;  /**< Pressure of touch */
+    uint8_t  area;      /**< touch area */
+} cst816s_touch_data_t;
+
+typedef struct {
+    /* I2C details */
+    i2c_t i2c_dev;                      /**< I2C device which is used */
+    uint8_t i2c_addr;                   /**< I2C address */
+    gpio_t irq;                         /**< IRQ pin */
+    gpio_flank_t irq_flank;             /**< IRQ flank */
+    gpio_t reset;                       /**< Device reset GPIO */
+} cst816s_params_t;
+
+/**
+ * @brief cst816s device descriptor
+ */
+struct _cst816s {
+    const cst816s_params_t *params;     /**< Device parameters */
+    cst816s_irq_cb_t cb;                /**< Configured IRQ event callback */
+    void *cb_arg;                       /**< Extra argument for the callback */
+};
+
+/**
+ * @brief   Status and error return codes
+ */
+enum {
+    CST816S_OK           =  0,     /**< everything was fine */
+    CST816S_ERR_IRQ      = -1,     /**< IRQ initialization error */
+};
+
+/**
+ * @brief   Initialize the given cst816s device
+ *
+ * @param[out] dev      device descriptor of the given cst816s device
+ * @param[in]  params   static configuration parameters
+ * @param[in]  cb       callback for the cst816s event interrupt, may be NULL
+ * @param[in]  arg      extra argument passed to the event interrupt.
+ *
+ * @returns             CST816S_OK on success
+ * @returns             CST816S_ERR_IRQ on IRQ initialization error
+ */
+int cst816s_init(cst816s_t *dev, const cst816s_params_t *params,
+                 cst816s_irq_cb_t cb, void *arg);
+
+/**
+ * @brief   Read touch data from the cst816s device
+ *
+ * @param[in]   dev     device descriptor
+ * @param[out]  data    Touch data array
+ * @param[in]   num     Number of entries in @p data
+ *
+ * @returns             the number of touch entries available in @p data
+ * @returns             negative on I2C access error
+ */
+int cst816s_read(cst816s_t *dev, cst816s_touch_data_t *data, size_t num);
+
+/**
+ * @brief   Suspend the given cst816s device
+ *
+ * @param[in]   dev     device descriptor
+ *
+ * @returns             CST816S_OK on success
+ * @returns             negative on I2C access error
+ */
+int cst816s_suspend(cst816s_t *dev);
+
+/**
+ * @brief   Resume the given cst816s device
+ *
+ * @param[in]   dev     device descriptor
+ */
+void cst816s_resume(cst816s_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CST816_H */
+/** @} */

--- a/drivers/include/ili9341.h
+++ b/drivers/include/ili9341.h
@@ -183,6 +183,14 @@ void ili9341_invert_on(ili9341_t *dev);
  */
 void ili9341_invert_off(ili9341_t *dev);
 
+/**
+ * @brief   Set display brightness
+ *
+ * @param[in]   dev         device descriptor
+ * @param[in]   brightness  brightness value to set
+ */
+void ili9341_set_brightness(ili9341_t *dev, uint8_t brightness);
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/include/ili9341.h
+++ b/drivers/include/ili9341.h
@@ -191,6 +191,14 @@ void ili9341_invert_off(ili9341_t *dev);
  */
 void ili9341_set_brightness(ili9341_t *dev, uint8_t brightness);
 
+/**
+ * @brief   Set display on or off
+ *
+ * @param[in]   dev         device descriptor
+ * @param[in]   enable      whether to enable the sleep mode
+ */
+void ili9341_sleep_mode(ili9341_t *dev, bool enable);
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/include/xpt2046.h
+++ b/drivers/include/xpt2046.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2018 Koen Zandberg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_xpt2046 XPT2046 touch screen driver
+ * @ingroup     drivers_sensors
+ *
+ * @{
+ * @file
+ * @brief       Device driver interface for the XPT2046 touch screen sensor.
+ *
+ * @details     There are three sensor values that can be read: x, y and z
+ *              values. This sensor will read all three values in one
+ *              measurement sequence
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ */
+
+#ifndef XPT2046_H
+#define XPT2046_H
+
+#include "periph/spi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef XPT2046_PRESSURE_TOUCH_LEVEL
+#define XPT2046_PRESSURE_TOUCH_LEVEL        10000
+#endif /* XPT2046_PRESSURE_TOUCH_LEVEL */
+
+/**
+ * @brief   Parameters for the xpt2046 sensor
+ *
+ * These parameters are needed to configure the device at startup.
+ */
+typedef struct {
+    spi_t spi;              /**< SPI device which is used */
+    spi_clk_t spi_clk;      /**< SPI speed to use */
+    spi_cs_t cs_pin;        /**< GPIO pin connected to chip select */
+    gpio_t int_pin;         /**< GPIO pin connected to the interrupt pin */
+} xpt2046_params_t;
+
+/**
+ * @brief   Device descriptor for the xpt2046 sensor
+ */
+typedef struct {
+    const xpt2046_params_t *params;             /**< Device Parameters */
+} xpt2046_t;
+
+/**
+ * @name Device measurement struct
+ */
+typedef struct {
+    uint16_t x;                 /**< X position of the measurement */
+    uint16_t y;                 /**< Y position of the measurement */
+    uint16_t z;                 /**< Pressure measurement */
+} xpt2046_xyz_t;
+
+/**
+ * @brief   Status and error return codes
+ */
+enum {
+    XPT2046_ERR_SPI         = -1,  /**< error initializing the SPI bus */
+    XPT2046_OK              =  0,  /**< everything is fine */
+    XPT2046_NO_TOUCH        =  1,  /**< No touch detected during measurement */
+    XPT2046_TOUCH_DETECTED  =  2,  /**< Touch detected during measurement */
+};
+
+/**
+ * @brief   Initialize the given XPT2046 device
+ *
+ * @param[out] dev          Initialized device descriptor of XPT2046 device
+ * @param[in]  params       The parameters for the XPT2046 device (sampling rate, etc)
+ *
+ * @return                  XPT2046_OK on success
+ * @return                  XPT2046_ERR_SPI
+ */
+int xpt2046_init(xpt2046_t* dev, const xpt2046_params_t* params);
+
+/**
+ * @brief   Do a touch screen measurement
+ *
+ * @param[in]  dev          XPT2046 device descriptor
+ * @param[out] measure      Measurement struct for the output values
+ *
+ * @return                  XPT2046_TOUCH_DETECTED on touch detected
+ * @return                  XPT2046_NO_TOUCH if no touch was detected
+ */
+int xpt2046_get_xyz(const xpt2046_t* dev, xpt2046_xyz_t* measure);
+
+uint16_t xpt2046_get_temp(const xpt2046_t* dev);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* XPT2046_H */
+/** @} */

--- a/drivers/xpt2046/Makefile
+++ b/drivers/xpt2046/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/xpt2046/include/xpt2046_internal.h
+++ b/drivers/xpt2046/include/xpt2046_internal.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2018 Koen Zandberg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_xpt2046
+ * @{
+ *
+ * @file
+ * @brief       Internal constants for xpt2046 touch screen sensors.
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+
+
+#ifndef XPT2046_INTERNAL_H
+#define XPT2046_INTERNAL_H
+
+#include "periph/spi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define XPT2046_SER     0x04 /* Single ended measurement */
+#define XPT2046_8BIT    0x08
+#define XPT2046_START   0x80
+
+#define XPT2046_TEMP0   0x00
+#define XPT2046_Y       0x10
+#define XPT2046_VBAT    0x20
+#define XPT2046_Z1      0x30
+#define XPT2046_Z2      0x40
+#define XPT2046_X       0x50
+#define XPT2046_AUX     0x60
+#define XPT2046_TEMP1   0x70
+
+#define XPT2046_OFF     0x00
+#define XPT2046_ADC_ON  0x01
+#define XPT2046_REF_ON  0x02
+#define XPT2046_ALL_ON  0x03
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* XPT2046_INTERNAL_H */
+/** @} */

--- a/drivers/xpt2046/xpt2046.c
+++ b/drivers/xpt2046/xpt2046.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2018 Koen Zandberg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_xpt2046
+ * @{
+ *
+ * @file
+ * @brief       Device driver implementation for the XPT2046 touch screen sensors
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+
+
+#include <string.h>
+#include "periph/spi.h"
+#include "xpt2046.h"
+#include "xpt2046_internal.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+const uint8_t measure_xyz[] = {
+    XPT2046_START | XPT2046_Z1 | XPT2046_ADC_ON,
+    0x00,
+    XPT2046_START | XPT2046_Z2 | XPT2046_ADC_ON,
+    0x00,
+    XPT2046_START | XPT2046_Y | XPT2046_ADC_ON,
+    0x00,
+    XPT2046_START | XPT2046_X | XPT2046_OFF,
+    0x00,
+    0x00,
+};
+
+const uint8_t measure_temp[] = {
+    XPT2046_START | XPT2046_TEMP0 | XPT2046_SER | XPT2046_ALL_ON,
+    0x00,
+    XPT2046_START | XPT2046_TEMP1 | XPT2046_SER | XPT2046_ALL_ON,
+    0x00,
+    XPT2046_START | XPT2046_SER | XPT2046_ALL_ON,
+    0x00,
+    0x00,
+};
+
+static uint16_t diff_to_kelvin(uint16_t adc_diff)
+{
+    return (1472) * adc_diff;
+}
+
+int xpt2046_get_xyz(const xpt2046_t *dev, xpt2046_xyz_t *measure)
+{
+    (void)measure;
+    uint8_t recv[sizeof(measure_xyz)];
+    spi_acquire(dev->params->spi, dev->params->cs_pin, SPI_MODE_0,
+                dev->params->spi_clk);
+    spi_transfer_bytes(dev->params->spi, dev->params->cs_pin, false,
+                       measure_xyz, recv, sizeof(measure_xyz));
+    spi_release(dev->params->spi);
+    measure->y = ((recv[5] << 5) | (recv[6] >> 3));
+    measure->x = ((recv[7] << 5) | (recv[8] >> 3));
+    uint16_t z1 = ((recv[1] << 5) | (recv[2] >> 3));
+    uint16_t z2 = ((recv[3] << 5) | (recv[4] >> 3));
+    measure->z = ((((uint32_t)z2 * (uint32_t)measure->x) / z1) - measure->x);
+    return measure->z < XPT2046_PRESSURE_TOUCH_LEVEL ?
+            XPT2046_TOUCH_DETECTED : XPT2046_NO_TOUCH;
+}
+
+uint16_t xpt2046_get_temp(const xpt2046_t *dev)
+{
+    uint8_t recv[sizeof(measure_temp)];
+
+    spi_acquire(dev->params->spi, dev->params->cs_pin, SPI_MODE_0,
+                dev->params->spi_clk);
+    spi_transfer_bytes(dev->params->spi, dev->params->cs_pin, false,
+                       measure_temp, recv, sizeof(measure_xyz));
+    spi_release(dev->params->spi);
+    uint16_t temp0 = ((recv[3] * 32) | (recv[4] >> 3));
+    uint16_t temp1 = ((recv[5] * 32) | (recv[6] >> 3));
+    uint16_t kelvin = diff_to_kelvin(temp1 - temp0);
+    DEBUG("[xpt2046]: recv: %x, %x, %x, %x, %x, %x, %x\n", recv[0], recv[1],
+          recv[2], recv[3], recv[4], recv[5], recv[6]);
+    DEBUG("[xpt2046]: temperature: %d K, t0: %d, t1: %d\n", kelvin, temp0,
+          temp1);
+    return kelvin;
+}
+
+int xpt2046_init(xpt2046_t *dev, const xpt2046_params_t *params)
+{
+    dev->params = params;
+    int res = spi_init_cs(dev->params->spi, dev->params->cs_pin);
+    if (res != SPI_OK) {
+        DEBUG("[xpt2046] init: error initializing the CS pin [%i]\n", res);
+        return XPT2046_ERR_SPI;
+    }
+    return XPT2046_OK;
+}

--- a/examples/filesystem/main.c
+++ b/examples/filesystem/main.c
@@ -199,6 +199,7 @@ static int _cat(int argc, char **argv)
     }
     close(fd);
 #endif
+    putchar('\n');
     return 0;
 }
 

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -54,6 +54,7 @@ PSEUDOMODULES += log
 PSEUDOMODULES += log_printfnoformat
 PSEUDOMODULES += log_color
 PSEUDOMODULES += lora
+PSEUDOMODULES += lvgl
 PSEUDOMODULES += mpu_stack_guard
 PSEUDOMODULES += nanocoap_%
 PSEUDOMODULES += netdev_default

--- a/pkg/lvgl/Makefile
+++ b/pkg/lvgl/Makefile
@@ -3,6 +3,8 @@ PKG_URL=https://github.com/littlevgl/lvgl
 PKG_VERSION=f6f5f691f73e433eb32f831c8356e602058267fb
 PKG_LICENSE=MIT
 
+include $(RIOTBASE)/pkg/pkg.mk
+
 TDIR = $(RIOTPKG)/$(PKG_NAME)
 PDIR = $(PKG_BUILDDIR)
 
@@ -36,5 +38,3 @@ lvgl_hal:
 
 lvgl_sdl:
 	"$(MAKE)" -C $(TDIR)/lv_sdl -f $(TDIR)/lvgl.sdl.mk
-
-include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/lvgl/Makefile
+++ b/pkg/lvgl/Makefile
@@ -1,0 +1,40 @@
+PKG_NAME=lvgl
+PKG_URL=https://github.com/littlevgl/lvgl
+PKG_VERSION=f6f5f691f73e433eb32f831c8356e602058267fb
+PKG_LICENSE=MIT
+
+TDIR = $(RIOTPKG)/$(PKG_NAME)
+PDIR = $(PKG_BUILDDIR)
+
+.PHONY: all
+
+SUBMODS := $(filter lvgl_%,$(USEMODULE))
+
+all: $(SUBMODS)
+
+# lvgl modules
+lvgl_core:
+	"$(MAKE)" -C $(PDIR)/src/lv_core -f $(TDIR)/lvgl.core.mk
+
+lvgl_draw:
+	"$(MAKE)" -C $(PDIR)/src/lv_draw -f $(TDIR)/lvgl.draw.mk
+
+lvgl_misc:
+	"$(MAKE)" -C $(PDIR)/src/lv_misc -f $(TDIR)/lvgl.misc.mk
+
+lvgl_objx:
+	"$(MAKE)" -C $(PDIR)/src/lv_objx -f $(TDIR)/lvgl.objx.mk
+
+lvgl_themes:
+	"$(MAKE)" -C $(PDIR)/src/lv_themes -f $(TDIR)/lvgl.themes.mk
+
+lvgl_font:
+	"$(MAKE)" -C $(PDIR)/src/lv_font -f $(TDIR)/lvgl.font.mk
+
+lvgl_hal:
+	"$(MAKE)" -C $(PDIR)/src/lv_hal -f $(TDIR)/lvgl.hal.mk
+
+lvgl_sdl:
+	"$(MAKE)" -C $(TDIR)/lv_sdl -f $(TDIR)/lvgl.sdl.mk
+
+include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/lvgl/Makefile.include
+++ b/pkg/lvgl/Makefile.include
@@ -1,0 +1,12 @@
+INCLUDES += -I$(PKGDIRBASE)/lvgl
+
+CFLAGS += -Wno-pedantic -Wno-unused-parameter -Wno-sign-compare -Wno-cast-function-type
+
+CFLAGS += -DLV_CONF_INCLUDE_SIMPLE -DLV_LVGL_H_INCLUDE_SIMPLE
+
+# Link SDL if enabled.
+ifneq (,$(filter lvgl_sdl,$(USEMODULE)))
+  INCLUDES += -I$(RIOTPKG)/lvgl/lv_sdl
+  CFLAGS += -DUSE_MONITOR=1 -DUSE_MOUSE=1
+  LINKFLAGS += `sdl2-config --libs`
+endif

--- a/pkg/lvgl/Makefile.lvgl
+++ b/pkg/lvgl/Makefile.lvgl
@@ -1,0 +1,1 @@
+include ${RIOTBASE}/Makefile.base

--- a/pkg/lvgl/lvgl.core.mk
+++ b/pkg/lvgl/lvgl.core.mk
@@ -1,0 +1,3 @@
+MODULE = lvgl_core
+
+include ${RIOTBASE}/Makefile.base

--- a/pkg/lvgl/lvgl.draw.mk
+++ b/pkg/lvgl/lvgl.draw.mk
@@ -1,0 +1,3 @@
+MODULE = lvgl_draw
+
+include ${RIOTBASE}/Makefile.base

--- a/pkg/lvgl/lvgl.font.mk
+++ b/pkg/lvgl/lvgl.font.mk
@@ -1,0 +1,3 @@
+MODULE = lvgl_font
+
+include ${RIOTBASE}/Makefile.base

--- a/pkg/lvgl/lvgl.hal.mk
+++ b/pkg/lvgl/lvgl.hal.mk
@@ -1,0 +1,3 @@
+MODULE = lvgl_hal
+
+include ${RIOTBASE}/Makefile.base

--- a/pkg/lvgl/lvgl.misc.mk
+++ b/pkg/lvgl/lvgl.misc.mk
@@ -1,0 +1,3 @@
+MODULE = lvgl_misc
+
+include ${RIOTBASE}/Makefile.base

--- a/pkg/lvgl/lvgl.objx.mk
+++ b/pkg/lvgl/lvgl.objx.mk
@@ -1,0 +1,3 @@
+MODULE = lvgl_objx
+
+include ${RIOTBASE}/Makefile.base

--- a/pkg/lvgl/lvgl.sdl.mk
+++ b/pkg/lvgl/lvgl.sdl.mk
@@ -1,0 +1,4 @@
+MODULE = lvgl_sdl
+CFLAGS += `sdl2-config --cflags`
+
+include ${RIOTBASE}/Makefile.base

--- a/pkg/lvgl/lvgl.themes.mk
+++ b/pkg/lvgl/lvgl.themes.mk
@@ -1,0 +1,3 @@
+MODULE = lvgl_themes
+
+include ${RIOTBASE}/Makefile.base

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME    = nimble
 PKG_URL     = https://github.com/apache/mynewt-nimble.git
-PKG_VERSION = c9ca947ed31a3514221819cb464d3226e5741450
+PKG_VERSION = 9746f2e94a4dd212f00ff4539866226619d0ee86
 PKG_LICENSE = Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME    = nimble
 PKG_URL     = https://github.com/apache/mynewt-nimble.git
-PKG_VERSION = 9746f2e94a4dd212f00ff4539866226619d0ee86
+PKG_VERSION = 7df04c1d982eef24c349cf70d00b0ecf3f8de01f
 PKG_LICENSE = Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME    = nimble
 PKG_URL     = https://github.com/apache/mynewt-nimble.git
-PKG_VERSION = 37245d0c3f239c35c0c734a337c7b6301fcfd70b
+PKG_VERSION = c9ca947ed31a3514221819cb464d3226e5741450
 PKG_LICENSE = Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/nimble/patches/0001-ble_gap-fix-log-duration.patch
+++ b/pkg/nimble/patches/0001-ble_gap-fix-log-duration.patch
@@ -1,0 +1,25 @@
+From 2b5cf471422fb44c4bbde0db0de4e714af3801bd Mon Sep 17 00:00:00 2001
+From: Koen Zandberg <koen@bergzand.net>
+Date: Tue, 7 Jan 2020 20:38:21 +0100
+Subject: [PATCH 1/2] ble_gap: fix log duration
+
+---
+ nimble/host/src/ble_gap.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/nimble/host/src/ble_gap.c b/nimble/host/src/ble_gap.c
+index d77d4143..977e8601 100644
+--- a/nimble/host/src/ble_gap.c
++++ b/nimble/host/src/ble_gap.c
+@@ -285,7 +285,7 @@ ble_gap_log_duration(int32_t duration_ms)
+     if (duration_ms == BLE_HS_FOREVER) {
+         BLE_HS_LOG(INFO, "duration=forever");
+     } else {
+-        BLE_HS_LOG(INFO, "duration=%dms", duration_ms);
++        BLE_HS_LOG(INFO, "duration=%ldms", (long int)duration_ms);
+     }
+ }
+ #endif
+-- 
+2.24.1
+

--- a/pkg/nimble/patches/0002-endian-use-RIOT-provided-byteorder-functions.patch
+++ b/pkg/nimble/patches/0002-endian-use-RIOT-provided-byteorder-functions.patch
@@ -1,0 +1,96 @@
+From b267b439766bc6a775c739195dfbabd0eadf4eec Mon Sep 17 00:00:00 2001
+From: Koen Zandberg <koen@bergzand.net>
+Date: Tue, 7 Jan 2020 20:41:50 +0100
+Subject: [PATCH 2/2] endian: use RIOT provided byteorder functions
+
+---
+ porting/nimble/include/os/endian.h | 52 ++----------------------------
+ 1 file changed, 3 insertions(+), 49 deletions(-)
+
+diff --git a/porting/nimble/include/os/endian.h b/porting/nimble/include/os/endian.h
+index e0230756..bc389742 100644
+--- a/porting/nimble/include/os/endian.h
++++ b/porting/nimble/include/os/endian.h
+@@ -6,7 +6,7 @@
+  * to you under the Apache License, Version 2.0 (the
+  * "License"); you may not use this file except in compliance
+  * with the License.  You may obtain a copy of the License at
+- * 
++ *
+  *  http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing,
+@@ -21,6 +21,8 @@
+ #define H_ENDIAN_
+ 
+ #include <inttypes.h>
++/* Use RIOT-provided byteorder functions */
++#include "byteorder.h"
+ 
+ #ifdef __cplusplus
+ extern "C" {
+@@ -55,30 +57,6 @@ extern "C" {
+ 
+ #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+ 
+-#ifndef ntohll
+-#define ntohll(x)  ((uint64_t)(x))
+-#endif
+-
+-#ifndef htonll
+-#define htonll(x)  ((uint64_t)(x))
+-#endif
+-
+-#ifndef ntohl
+-#define ntohl(x)   ((uint32_t)(x))
+-#endif
+-
+-#ifndef htonl
+-#define htonl(x)   ((uint32_t)(x))
+-#endif
+-
+-#ifndef ntohs
+-#define ntohs(x)   ((uint16_t)(x))
+-#endif
+-
+-#ifndef htons
+-#define htons(x)   ((uint16_t)(x))
+-#endif
+-
+ #ifndef htobe16
+ #define htobe16(x) ((uint16_t)(x))
+ #endif
+@@ -129,30 +107,6 @@ extern "C" {
+ 
+ #else
+ 
+-#ifndef ntohll
+-#define ntohll(x)   os_bswap_64(x)
+-#endif
+-
+-#ifndef htonll
+-#define htonll      ntohll
+-#endif
+-
+-#ifndef ntohl
+-#define ntohl(x)    os_bswap_32(x)
+-#endif
+-
+-#ifndef htonl
+-#define htonl       ntohl
+-#endif
+-
+-#ifndef htons
+-#define htons(x)    os_bswap_16(x)
+-#endif
+-
+-#ifndef ntohs
+-#define ntohs       htons
+-#endif
+-
+ #ifndef htobe16
+ #define htobe16(x) os_bswap_16(x)
+ #endif
+-- 
+2.24.1
+

--- a/tests/driver_cst816s/Makefile
+++ b/tests/driver_cst816s/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile.tests_common
+
+USEMODULE += cst816s
+USEMODULE += core_thread_flags
+
+CFLAGS += -DSTDIO_RTT_ENABLE_BLOCKING_STDOUT=1
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_cst816s/main.c
+++ b/tests/driver_cst816s/main.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the CST816S touch screen driver
+ *
+ * @author      koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "cst816s_params.h"
+#include "cst816s.h"
+#include "xtimer.h"
+#include "fmt.h"
+#include "thread.h"
+#include "thread_flags.h"
+
+static kernel_pid_t _pid;
+
+#define CST816S_THREAD_FLAG     (1 << 8)
+#define CST816S_NUM_TOUCHES     5
+
+static void _cb(cst816s_t *dev, void *arg)
+{
+    (void)dev;
+    (void)arg;
+    thread_flags_set((thread_t*)sched_threads[_pid], CST816S_THREAD_FLAG);
+}
+
+static int _dump_cst816s(cst816s_t *dev)
+{
+    puts("Reading data:");
+    cst816s_touch_data_t touches[CST816S_NUM_TOUCHES];
+    int num = cst816s_read(dev, touches, CST816S_NUM_TOUCHES);
+    if (num > 0) {
+        for (size_t i = 0; i < (size_t)num; i++) {
+            printf("Touch %u at %03u, %03u with finger %u\n", i, touches[i].x,
+                   touches[i].y, touches[i].finger);
+        }
+    }
+    else if (num == 0) {
+        puts("No touch detected on the screen");
+    }
+    else {
+        puts("Device not responding");
+    }
+    return num;
+}
+
+int main(void)
+{
+    cst816s_t dev;
+    _pid = sched_active_pid;
+
+    puts("CST816S test application\n");
+    cst816s_init(&dev, &cst816s_params[0], _cb, NULL);
+
+    while (1) {
+        thread_flags_t flags = thread_flags_wait_any(CST816S_THREAD_FLAG);
+        if (flags & CST816S_THREAD_FLAG) {
+            while (_dump_cst816s(&dev) >= 0) {
+                xtimer_usleep(500 * US_PER_MS);
+            }
+        }
+    }
+    return 0;
+}
+

--- a/tests/driver_xpt2046/Makefile
+++ b/tests/driver_xpt2046/Makefile
@@ -1,0 +1,22 @@
+include ../Makefile.tests_common
+
+BOARD ?= nrf52dk
+
+USEMODULE += xpt2046
+USEMODULE += xtimer
+USEMODULE += printf_float
+USEMODULE += core_thread_flags
+
+# set default device parameters in case they are undefined
+TEST_SPI ?= SPI_DEV\(0\)
+TEST_SPI_CS ?= GPIO_PIN\(0,28\)
+TEST_SPI_CLK ?= SPI_CLK_1MHZ
+
+# export parameters
+CFLAGS += -DTEST_SPI=$(TEST_SPI)
+CFLAGS += -DTEST_SPI_CS=$(TEST_SPI_CS)
+CFLAGS += -DTEST_SPI_CLK=$(TEST_SPI_CLK)
+
+DEVELHELP := 1
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_xpt2046/main.c
+++ b/tests/driver_xpt2046/main.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2018 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the xpt2046 touch screen sensor
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+
+#ifndef TEST_SPI
+#error "TEST_SPI not defined"
+#endif
+
+#ifndef TEST_SPI_CS
+#error "TEST_SPI_CS not defined"
+#endif
+
+#ifndef TEST_SPI_CLK
+#error "TEST_SPI_CLK not defined"
+#endif
+
+#include <stdio.h>
+#include "xtimer.h"
+#include "xpt2046.h"
+#include "periph/spi.h"
+
+int main(void)
+{
+    xpt2046_t dev;
+    xpt2046_params_t params = {
+        .spi = TEST_SPI,
+        .spi_clk = TEST_SPI_CLK,
+        .cs_pin = TEST_SPI_CS,
+    };
+
+    puts("xpt2046 touch screen test application\n");
+
+    /* initialize the sensor */
+    printf("Initializing touch screen...");
+
+    if (xpt2046_init(&dev, &params) == 0) {
+        puts("[OK]");
+    }
+    else {
+        puts("[Failed]");
+        return 1;
+    }
+
+    xtimer_ticks32_t ticks = xtimer_now();
+
+    while (1) {
+        xpt2046_xyz_t m;
+        xpt2046_get_xyz(&dev, &m);
+        printf("X: %" PRIu16 ", Y: %" PRIu16 ", Z: %" PRIu16"\n", m.x, m.y, m.z);
+        xtimer_periodic_wakeup(&ticks, 200 * US_PER_MS);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
enable building with gcc 6.3
followup on https://github.com/RIOT-OS/RIOT/pull/12123